### PR TITLE
TF Cleanup and Added Example

### DIFF
--- a/Terraform/AWS/EC2-agent/main.tf
+++ b/Terraform/AWS/EC2-agent/main.tf
@@ -1,4 +1,4 @@
-resource "aws_security_group" "morpheus_aio_sg" {
+resource "aws_security_group" "morpheus_sg" {
   name   = var.sec_group_name
   vpc_id = var.vpc
 
@@ -51,7 +51,7 @@ resource "aws_instance" "morpheus" {
    - <%=instance.cloudConfig.finalizeServer%>
    EOF
 
-  vpc_security_group_ids = [aws_security_group.morpheus_aio_sg.id]
+  vpc_security_group_ids = [aws_security_group.morpheus_sg.id]
   root_block_device {
     delete_on_termination = true
     volume_size           = 50
@@ -61,7 +61,7 @@ resource "aws_instance" "morpheus" {
   }
 
 
-  depends_on = [aws_security_group.morpheus_aio_sg]
+  depends_on = [aws_security_group.morpheus_sg]
 }
 
 data "aws_subnets" "subnets" {

--- a/Terraform/AWS/EC2-agent/variables.tf
+++ b/Terraform/AWS/EC2-agent/variables.tf
@@ -35,9 +35,3 @@ variable "sec_group_name" {
   description = "Will create the security group specified and assign to instance"
   default     = "morpheus-aio-sec-group"
 }
-
-variable "download" {
-  type        = string
-  description = "Enter the full download url of the Morpheus install. Currently requires Amazon Linux 2 version"
-  default     = "https://downloads.morpheusdata.com/files/morpheus-appliance-5.4.3-1.amzn2.x86_64.rpm"
-}

--- a/Terraform/AWS/simpleRoute53/main.tf
+++ b/Terraform/AWS/simpleRoute53/main.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_record" "morpheusR53" {
+  zone_id = var.hosted_zone_id
+  name    = var.record_name
+  type    = "A"
+  ttl     = "300"
+  records = [var.record_ip]
+}

--- a/Terraform/AWS/simpleRoute53/outputs.tf
+++ b/Terraform/AWS/simpleRoute53/outputs.tf
@@ -1,0 +1,4 @@
+output "fqdn" {
+  description = "FQDN of the record created"
+  value       = aws_route53_record.morpheusR53.fqdn
+}

--- a/Terraform/AWS/simpleRoute53/provider.tf
+++ b/Terraform/AWS/simpleRoute53/provider.tf
@@ -1,0 +1,11 @@
+terraform {
+    required_version = ">= 0.14.5"
+    required_providers {
+        aws = ">= 4.0.0"
+    }
+}
+provider "aws" {
+    region = var.region
+    access_key = var.access_key
+    secret_key = var.secret_key
+}

--- a/Terraform/AWS/simpleRoute53/variables.tf
+++ b/Terraform/AWS/simpleRoute53/variables.tf
@@ -1,0 +1,10 @@
+variable "access_key" {}
+variable "secret_key" {}
+variable "region" {
+    default = "us-east-1"
+}
+variable "hosted_zone_id" {}
+variable "record_name" {
+    default = "morpheusR53"
+}
+variable "record_ip" {}


### PR DESCRIPTION
Removed an unneeded variable from EC2 agent deploy and changed a resource name for consistency

Added a Route 53 example, similar to the S3 bucket example